### PR TITLE
Profile CRUD 기능 생성

### DIFF
--- a/src/main/java/jusomejusome/togather/exception/type/ErrorCode.java
+++ b/src/main/java/jusomejusome/togather/exception/type/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
 
     //프로필 관련 오류 - C2***
     PROFILE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "C2000", "해당 프로필 정보를 찾을 수 없습니다."),
-    NO_AUTHORITY_PROFILE_REMOVE(HttpStatus.UNAUTHORIZED, "C2001", "본인의 프로필만 삭제할 수 있습니다.");
+    NO_AUTHORITY_PROFILE_REMOVE(HttpStatus.UNAUTHORIZED, "C2001", "본인의 프로필만 삭제할 수 있습니다."),
+    NO_AUTHORITY_PROFILE_UPDATE(HttpStatus.UNAUTHORIZED, "C2002", "본인의 프로필만 수정할 수 있습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/jusomejusome/togather/exception/type/ErrorCode.java
+++ b/src/main/java/jusomejusome/togather/exception/type/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "C1007", "토큰이 유효하지 않습니다."),
 
     //프로필 관련 오류 - C2***
-    PROFILE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "C2000", "해당 프로필 정보를 찾을 수 없습니다.");
+    PROFILE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "C2000", "해당 프로필 정보를 찾을 수 없습니다."),
+    NO_AUTHORITY_PROFILE_REMOVE(HttpStatus.UNAUTHORIZED, "C2001", "본인의 프로필만 삭제할 수 있습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/jusomejusome/togather/exception/type/ErrorCode.java
+++ b/src/main/java/jusomejusome/togather/exception/type/ErrorCode.java
@@ -19,7 +19,11 @@ public enum ErrorCode {
     WRONG_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "C1004", "패스워드가 올바르지 않습니다."),
     EXPIRED_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "C1005", "토큰이 유효하지 않습니다."),
     INVALID_TOKEN_TYPE_EXCEPTION(HttpStatus.UNAUTHORIZED, "C1006", "토큰 타입이 올바르지 않습니다."),
-    INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "C1007", "토큰이 유효하지 않습니다.");
+    INVALID_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, "C1007", "토큰이 유효하지 않습니다."),
+
+    //프로필 관련 오류 - C2***
+    PROFILE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "C2000", "해당 프로필 정보를 찾을 수 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
+++ b/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
@@ -17,4 +17,10 @@ public class ProfileController {
     public ProfileResDto createProfile(@PathVariable Long calendarId, @AuthUser User user) {
         return profileService.createProfile(calendarId, user);
     }
+
+    @GetMapping("/{id}")
+    public ProfileResDto getProfileById(@PathVariable Long id) {
+        return profileService.findProfileById(id);
+    }
+
 }

--- a/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
+++ b/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
@@ -5,6 +5,8 @@ import jusomejusome.togather.profile.dto.response.ProfileResDto;
 import jusomejusome.togather.profile.service.ProfileService;
 import jusomejusome.togather.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,4 +25,9 @@ public class ProfileController {
         return profileService.findProfileById(id);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteProfile(@PathVariable Long id, @AuthUser User user) {
+        profileService.deleteProfile(id, user);
+        return new ResponseEntity<>("프로필이 삭제되었습니다. profileId = " + id, HttpStatus.OK);
+    }
 }

--- a/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
+++ b/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package jusomejusome.togather.profile.controller;
 
 import jusomejusome.togather.config.authentication.AuthUser;
+import jusomejusome.togather.profile.dto.request.ProfileUpdateReqDto;
 import jusomejusome.togather.profile.dto.response.ProfileResDto;
 import jusomejusome.togather.profile.service.ProfileService;
 import jusomejusome.togather.user.domain.User;
@@ -30,4 +31,10 @@ public class ProfileController {
         profileService.deleteProfile(id, user);
         return new ResponseEntity<>("프로필이 삭제되었습니다. profileId = " + id, HttpStatus.OK);
     }
+
+    @PutMapping("/{id}")
+    public ProfileResDto updateProfile(@PathVariable Long id, @RequestBody ProfileUpdateReqDto profileUpdateReqDto, @AuthUser User user){
+        return profileService.updateProfile(id, profileUpdateReqDto, user);
+    }
+
 }

--- a/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
+++ b/src/main/java/jusomejusome/togather/profile/controller/ProfileController.java
@@ -1,0 +1,20 @@
+package jusomejusome.togather.profile.controller;
+
+import jusomejusome.togather.config.authentication.AuthUser;
+import jusomejusome.togather.profile.dto.response.ProfileResDto;
+import jusomejusome.togather.profile.service.ProfileService;
+import jusomejusome.togather.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/profiles")
+public class ProfileController {
+    private final ProfileService profileService;
+
+    @PostMapping("/{calendarId}")
+    public ProfileResDto createProfile(@PathVariable Long calendarId, @AuthUser User user) {
+        return profileService.createProfile(calendarId, user);
+    }
+}

--- a/src/main/java/jusomejusome/togather/profile/domain/Profile.java
+++ b/src/main/java/jusomejusome/togather/profile/domain/Profile.java
@@ -54,4 +54,8 @@ public class Profile extends BaseTimeEntity {
         this.organization = organization;
     }
 
+    public boolean isAuthorizedUser(User user) {
+        return this.user.equals(user);
+    }
+
 }

--- a/src/main/java/jusomejusome/togather/profile/domain/Profile.java
+++ b/src/main/java/jusomejusome/togather/profile/domain/Profile.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jusomejusome.togather.global.BaseTimeEntity;
 import jusomejusome.togather.user.domain.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,5 +41,17 @@ public class Profile extends BaseTimeEntity {
 
     @Column(length = 100)
     private String organization;
+
+    @Builder
+    public Profile(User user, Long mainCalendarId, String nickname, String profileImageUrl, String job, String introduce, String website, String organization) {
+        this.user = user;
+        this.mainCalendarId = mainCalendarId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.job = job;
+        this.introduce = introduce;
+        this.website = website;
+        this.organization = organization;
+    }
 
 }

--- a/src/main/java/jusomejusome/togather/profile/domain/Profile.java
+++ b/src/main/java/jusomejusome/togather/profile/domain/Profile.java
@@ -58,4 +58,12 @@ public class Profile extends BaseTimeEntity {
         return this.user.equals(user);
     }
 
+    public void update(String nickname, String profileImageUrl, String job, String introduce, String website, String organization) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.job = job;
+        this.introduce = introduce;
+        this.website = website;
+        this.organization = organization;
+    }
 }

--- a/src/main/java/jusomejusome/togather/profile/dto/request/ProfileUpdateReqDto.java
+++ b/src/main/java/jusomejusome/togather/profile/dto/request/ProfileUpdateReqDto.java
@@ -1,0 +1,13 @@
+package jusomejusome.togather.profile.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileUpdateReqDto {
+    private String nickname;
+    private String profileImageUrl;
+    private String job;
+    private String introduce;
+    private String website;
+    private String organization;
+}

--- a/src/main/java/jusomejusome/togather/profile/dto/response/ProfileResDto.java
+++ b/src/main/java/jusomejusome/togather/profile/dto/response/ProfileResDto.java
@@ -1,0 +1,32 @@
+package jusomejusome.togather.profile.dto.response;
+
+import jusomejusome.togather.profile.domain.Profile;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileResDto {
+    private Long profileId;
+    private Long userId;
+    private Long mainCalendarId;
+    private String nickname;
+    private String profileImageUrl;
+    private String job;
+    private String introduce;
+    private String website;
+    private String organization;
+
+    public static ProfileResDto from(Profile profile) {
+        return new ProfileResDto(profile.getProfileId(),
+                profile.getUser().getUserId(),
+                profile.getMainCalendarId(),
+                profile.getNickname(),
+                profile.getProfileImageUrl(),
+                profile.getJob(),
+                profile.getIntroduce(),
+                profile.getWebsite(),
+                profile.getOrganization());
+    }
+}

--- a/src/main/java/jusomejusome/togather/profile/repository/ProfileRepository.java
+++ b/src/main/java/jusomejusome/togather/profile/repository/ProfileRepository.java
@@ -1,0 +1,7 @@
+package jusomejusome.togather.profile.repository;
+
+import jusomejusome.togather.profile.domain.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+}

--- a/src/main/java/jusomejusome/togather/profile/service/ProfileService.java
+++ b/src/main/java/jusomejusome/togather/profile/service/ProfileService.java
@@ -1,0 +1,36 @@
+package jusomejusome.togather.profile.service;
+
+import jusomejusome.togather.exception.custom.CustomException;
+import jusomejusome.togather.exception.type.ErrorCode;
+import jusomejusome.togather.profile.domain.Profile;
+import jusomejusome.togather.profile.dto.response.ProfileResDto;
+import jusomejusome.togather.profile.repository.ProfileRepository;
+import jusomejusome.togather.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class ProfileService {
+    private final ProfileRepository profileRepository;
+
+    public ProfileResDto createProfile(Long calendarId, User user) {
+        Profile profile = profileRepository.save(Profile.builder()
+                .user(user)
+                .mainCalendarId(calendarId)
+                .nickname(user.getPhone().substring(user.getPhone().length() - 4)) //임시로 전화번호 뒤 4자리를 닉네임으로 설정
+                .build());
+        return findProfileById(profile.getProfileId());
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileResDto findProfileById(Long id) {
+        Profile profile = profileRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND_EXCEPTION));
+        return ProfileResDto.from(profile);
+    }
+}

--- a/src/main/java/jusomejusome/togather/profile/service/ProfileService.java
+++ b/src/main/java/jusomejusome/togather/profile/service/ProfileService.java
@@ -33,4 +33,13 @@ public class ProfileService {
                 .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND_EXCEPTION));
         return ProfileResDto.from(profile);
     }
+
+    public void deleteProfile(Long id, User user) {
+        Profile profile = profileRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND_EXCEPTION));
+        if(!profile.isAuthorizedUser(user)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_PROFILE_REMOVE);
+        }
+        profileRepository.delete(profile);
+    }
 }

--- a/src/main/java/jusomejusome/togather/profile/service/ProfileService.java
+++ b/src/main/java/jusomejusome/togather/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package jusomejusome.togather.profile.service;
 import jusomejusome.togather.exception.custom.CustomException;
 import jusomejusome.togather.exception.type.ErrorCode;
 import jusomejusome.togather.profile.domain.Profile;
+import jusomejusome.togather.profile.dto.request.ProfileUpdateReqDto;
 import jusomejusome.togather.profile.dto.response.ProfileResDto;
 import jusomejusome.togather.profile.repository.ProfileRepository;
 import jusomejusome.togather.user.domain.User;
@@ -42,4 +43,16 @@ public class ProfileService {
         }
         profileRepository.delete(profile);
     }
+
+    public ProfileResDto updateProfile(Long id, ProfileUpdateReqDto profileUpdateReqDto, User user) {
+        Profile profile = profileRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROFILE_NOT_FOUND_EXCEPTION));
+        if(!profile.isAuthorizedUser(user)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_PROFILE_UPDATE);
+        }
+        profile.update(profileUpdateReqDto.getNickname(), profileUpdateReqDto.getProfileImageUrl(), profileUpdateReqDto.getJob(),
+                profileUpdateReqDto.getIntroduce(), profileUpdateReqDto.getWebsite(), profileUpdateReqDto.getOrganization());
+        return ProfileResDto.from(profile);
+    }
+
 }


### PR DESCRIPTION
## 📝 작업 내용
- [x] 프로필 생성 API
- [x]  프로필 수정 API
- [x] 프로필 조회 API
- [x] 프로필 삭제 API

</br>

### 📸 결과
- `POST` 프로필 생성(`/api/v1/profiles/{mainCalendarId}`)
  - 한 User 당 한 개의 Profile만 생성 가능(1:1 관계)
  - API 요청 보낼 때 헤더 `Authorization`에 액세스 토큰 삽입 -> 포스트맨 참고
  - responseBody
  ```json
  {
      "profileId": 3,
      "userId": 6,
      "mainCalendarId": 2,
      "nickname": "4610",
      "profileImageUrl": null,
      "job": null,
      "introduce": null,
      "website": null,
      "organization": null
  }
  ```

- `GET` 프로필 조회(`/api/v1/profiles/{profileId}`)
  - responseBody
   ```json
   {
      "profileId": 3,
      "userId": 6,
      "mainCalendarId": 2,
      "nickname": "4610",
      "profileImageUrl": null,
      "job": null,
      "introduce": null,
      "website": null,
      "organization": null
   }
  ```


- `PUT` 프로필 수정(`/api/v1/profiles/{profileId}`)
  - 본인 프로필만 수정 가능(API 요청 보낼 때 헤더 `Authorization`에 액세스 토큰 삽입) -> 포스트맨 참고
  - requestBody
  ```json
  {
    "mainCalendarId":1,
    "nickname": "bean",
    "profileImageUrl": "www.s3",
    "job": "Student",
    "introduce": "Hi",
    "website": "www.velog",
    "organization": "EWHA"
  }
  ```
  - responseBody
    - 프로필 조회와 같은 response

- `DELETE` 프로필 삭제(`/api/v1/profiles/{profileId}`)
  - 본인 프로필만 수정 가능(API 요청 보낼 때 헤더 `Authorization`에 액세스 토큰 삽입) -> 포스트맨 참고
  - response
  ```
  프로필이 삭제되었습니다. profileId = 3
  ```

</br>

## 💬 리뷰 요구사항 (선택)

</br>

## #️⃣ 연관된 이슈 (선택)
close #2

